### PR TITLE
[SDMAPLUS - URGENT] CMD-42069: Fix wrong SC location

### DIFF
--- a/home/clonerer.nix
+++ b/home/clonerer.nix
@@ -2,7 +2,7 @@
 let
   /* The 'clonerer' is a tool which clones git repos to specified locations and sets up additional git remotes for them. */
 
-  gitBasePath = "/home/sez/SC";
+  gitBasePath = "/SC";
   configFile = pkgs.writeText "clonerer-config.json" (builtins.toJSON [
     {
       name = "portfolio";


### PR DESCRIPTION
```
fix(SC): use correct location for source control folder

relates to CMD-42069
```

The SC folder MUST be located at system level! Like described in QWiki. Else the CD-Verwaltung won't compile!